### PR TITLE
Adding google-universal and the tracking id to _config.yml.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,10 @@
 
 # theme/remote_theme for GitHub pages compatability.
 # theme: minimal-mistakes-jekyll
+
+# Production Build of boost-starai.github.io
+#JEKYLL_ENV=production jekyll build
+
 remote_theme: "mmistakes/minimal-mistakes"
 
 minimal_mistakes_skin    : "contrast" #"default", "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
@@ -30,9 +34,9 @@ title			 : "STARLinG"
 title_separator          : "-"
 name                     : "Alexander L. Hayes & Harsha Kokel"
 description              : "Webpage for the STARLinG Lab. An Artificial Intelligence research group at the University of Texas at Dallas."
-url                      : # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
+url                      : "https://boost-starai.github.io" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
-repository               : HumanInTheLoop
+repository               : "boost-starai"
 teaser                   : # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 breadcrumbs              : false # true, false (default)
 words_per_minute         : 200
@@ -94,9 +98,9 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "custom"
+  provider               :  "google-universal" #false (default), "google", "google-universal", "custom"
   google:
-    tracking_id          :
+    tracking_id          : "UA-99296192-3"
 
 
 # Site Author


### PR DESCRIPTION
Until we have a true production copy of the webpage ready, we should keep this pull request open but unmerged. Until then, any data will likely be due to internal traffic.