### PR TITLE
Fixing Shuo Yang's website address

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -275,7 +275,7 @@ Phillip Odom:
 
 Shuo Yang:
   name: "Shuo Yang"
-  uri: "http://homes.soic.indiana.edu/shuoyang/"
+  uri: "https://shuoyang.netlify.com/"
   avatar: "/assets/images/headshots/shuoyang.jpg"
   location: "Amobee"
   email: "shuoyang@indiana.edu"


### PR DESCRIPTION
* [X] Summary of changes

This PR points Shuo Yang's `uri` to https://shuoyang.netlify.com/ instead of http://homes.soic.indiana.edu/shuoyang/