### PR TITLE
🐛 QuaKE - Fix broken link by adding a redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-redirect-from"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,7 @@ DEPENDENCIES
   jekyll (~> 3.9)
   jekyll-feed (~> 0.6)
   jekyll-include-cache
+  jekyll-redirect-from
   minimal-mistakes-jekyll
   tzinfo-data
   wdm (~> 0.1.0)

--- a/_config.yml
+++ b/_config.yml
@@ -200,6 +200,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-redirect-from
 
 # mimic GitHub Pages with --safe
 whitelist:

--- a/_posts/2021-04-05-QuaKE.md
+++ b/_posts/2021-04-05-QuaKE.md
@@ -6,7 +6,10 @@ categories: paper
 description: 'by Athresh Karanam, Alexander L. Hayes, Harsha Kokel, David M. Haas, Predrag Radivojac, Sriraam Natarajan, In AIME 2021'
 excerpt: '<i>Athresh Karanam, Alexander L. Hayes, Harsha Kokel, David M. Haas, Predrag Radivojac, Sriraam Natarajan</i><br/><br/>{::nomarkdown}  <a href="/assets/pdfs/KaranamHayes_AIME2021.pdf" class="btn btn--light-outline btn--large"><i class="fas fa-file-pdf"></i> Paper</a>  <a href="/assets/pdfs/KaranamHayes_AIME2021_sup.pdf" class="btn btn--light-outline btn--large"><i class="fas fa-paperclip"></i> Appendix</a>{:/nomarkdown}'
 header:
-  overlay_color: SteelBlue  
+  overlay_color: SteelBlue
+redirect_from:
+  - /papers/quake/
+  - /papers/QuAKE/
 ---
 
 ## Quick Overview


### PR DESCRIPTION
I realized footnote 5 in the QuaKE-AIME-2021 paper said the following:

![image](https://user-images.githubusercontent.com/11916674/122127885-dba14300-ce01-11eb-867a-215fec8f5ceb.png)

https://starling.utdallas.edu/papers/QuAKE/ is a broken link, the correct spelling is to [QuaKE](https://starling.utdallas.edu/papers/QuaKE/)

---

This adds the `jekyll-redirect-from` plugin to the `_config.yml` and the `Gemfile`, and redirects requests from these urls:

- `/papers/quake/`
- `/papers/QuAKE/`